### PR TITLE
Add DenyExportMessageFrom to the Barrier of BH

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2077,6 +2077,7 @@ dependencies = [
  "asset-hub-polkadot-runtime",
  "bp-bridge-hub-polkadot",
  "bp-messages",
+ "bridge-hub-common",
  "bridge-hub-polkadot-runtime",
  "cumulus-pallet-xcmp-queue",
  "emulated-integration-tests-common",

--- a/integration-tests/emulated/tests/bridges/bridge-hub-polkadot/Cargo.toml
+++ b/integration-tests/emulated/tests/bridges/bridge-hub-polkadot/Cargo.toml
@@ -38,6 +38,7 @@ pallet-bridge-messages = { workspace = true, default-features = true }
 
 # Local
 bp-bridge-hub-polkadot = { workspace = true, default-features = true }
+bridge-hub-common = { workspace = true, default-features = true }
 bridge-hub-polkadot-runtime = { workspace = true }
 asset-hub-polkadot-runtime = { workspace = true }
 integration-tests-helpers = { workspace = true }

--- a/system-parachains/constants/src/polkadot.rs
+++ b/system-parachains/constants/src/polkadot.rs
@@ -167,12 +167,14 @@ pub mod fee {
 pub mod locations {
 	use frame_support::parameter_types;
 	pub use polkadot_runtime_constants::system_parachain::AssetHubParaId;
-	use xcm::latest::prelude::{Junction::*, Location};
+	use xcm::latest::prelude::{Junction::*, Location, NetworkId};
 
 	parameter_types! {
 		pub AssetHubLocation: Location =
 			Location::new(1, Parachain(polkadot_runtime_constants::system_parachain::ASSET_HUB_ID));
 
 		pub GovernanceLocation: Location = Location::parent();
+
+		pub EthereumNetwork: NetworkId = NetworkId::Ethereum { chain_id: 1 };
 	}
 }


### PR DESCRIPTION
To mirror https://github.com/paritytech/polkadot-sdk/pull/8037, which appears to be missing from the BHP runtime configuration.

It seems there are no HRMP channels between non-system parachain and BHP, but IMO, adding this barrier could still be a worthwhile security enhancement.