### PR TITLE
Fix Snowbridge tests

### DIFF
--- a/system-parachains/bridge-hubs/bridge-hub-polkadot/src/bridge_to_ethereum_config.rs
+++ b/system-parachains/bridge-hubs/bridge-hub-polkadot/src/bridge_to_ethereum_config.rs
@@ -149,7 +149,7 @@ parameter_types! {
 		},
 		electra: Fork {
 			version: [5, 0, 0, 0], // 0x05000000
-			epoch: 5000000,
+			epoch: 0,
 		}
 	};
 }

--- a/system-parachains/bridge-hubs/bridge-hub-polkadot/tests/snowbridge.rs
+++ b/system-parachains/bridge-hubs/bridge-hub-polkadot/tests/snowbridge.rs
@@ -193,21 +193,19 @@ fn max_message_queue_service_weight_is_more_than_beacon_extrinsic_weights() {
 	max_message_queue_weight.all_gt(submit_checkpoint);
 }
 
-// TODO: fail-ci @clara @yrong please check why these tests are failing
-// #[test]
-// fn ethereum_client_consensus_extrinsics_work() {
-// 	ethereum_extrinsic(collator_session_keys(), 1013, construct_and_apply_extrinsic);
-// }
+#[test]
+fn ethereum_client_consensus_extrinsics_work() {
+	ethereum_extrinsic(collator_session_keys(), 1013, construct_and_apply_extrinsic);
+}
 
-// TODO: fail-ci @clara @yrong please check why these tests are failing
-// #[test]
-// fn ethereum_to_polkadot_message_extrinsics_work() {
-// 	snowbridge_runtime_test_common::ethereum_to_polkadot_message_extrinsics_work(
-// 		collator_session_keys(),
-// 		1013,
-// 		construct_and_apply_extrinsic,
-// 	);
-// }
+#[test]
+fn ethereum_to_polkadot_message_extrinsics_work() {
+	snowbridge_runtime_test_common::ethereum_to_polkadot_message_extrinsics_work(
+		collator_session_keys(),
+		1013,
+		construct_and_apply_extrinsic,
+	);
+}
 
 #[test]
 fn ethereum_outbound_queue_processes_messages_before_message_queue_works() {


### PR DESCRIPTION
Updates the current fork to Electra, since all the test fixtures now use Electra.
